### PR TITLE
Added Middleware support for K8s-Ingress

### DIFF
--- a/tunneload/src/configurator/kubernetes/ingress/ingress_parser.rs
+++ b/tunneload/src/configurator/kubernetes/ingress/ingress_parser.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fmt::Display};
+use std::{collections::BTreeMap, error::Error, fmt::Display};
 
 use async_trait::async_trait;
 use k8s_openapi::api::extensions::v1beta1::{HTTPIngressPath, Ingress};
@@ -6,8 +6,11 @@ use kube::api::Meta;
 
 use general::Shared;
 
-use crate::configurator::parser::{ParseRuleContext, Parser};
-use rules::{Matcher, Rule, Service};
+use crate::configurator::{
+    parser::{ParseRuleContext, Parser},
+    MiddlewareList,
+};
+use rules::{Matcher, Middleware, Rule, Service};
 
 /// The Parser for the Kubernetes-Ingress-Configuration
 pub struct IngressParser {
@@ -29,11 +32,42 @@ impl IngressParser {
         Self { priority }
     }
 
+    fn parse_middleware_annotations(
+        annotations: Option<BTreeMap<String, String>>,
+        middlewares: &MiddlewareList,
+    ) -> Vec<Shared<Middleware>> {
+        let annot = match annotations {
+            Some(a) => a,
+            None => return Vec::new(),
+        };
+
+        let raw_values = match annot.get("tunneload-middleware") {
+            Some(v) => v,
+            None => return Vec::new(),
+        };
+
+        let mut result = Vec::new();
+        for raw_name in raw_values.split(',') {
+            let name = raw_name.trim();
+
+            if name.len() == 0 {
+                continue;
+            }
+
+            let tmp_middle = middlewares.get_with_default(name);
+            result.push(tmp_middle);
+        }
+
+        result
+    }
+
     fn parse_path(
         http_path: &HTTPIngressPath,
         host: String,
         name: String,
         priority: u32,
+        annotations: Option<BTreeMap<String, String>>,
+        middlewares: &MiddlewareList,
     ) -> Result<Rule, PathError> {
         let backend = &http_path.backend;
         let service_name = backend
@@ -56,12 +90,14 @@ impl IngressParser {
             Matcher::PathPrefix(path.to_string()),
         ]);
 
+        let middlewares = Self::parse_middleware_annotations(annotations, middlewares);
+
         let addresses = vec![format!("{}:{}", service_name, service_port)];
         Ok(Rule::new(
             name,
             priority,
             matcher,
-            Vec::new(),
+            middlewares,
             Shared::new(Service::new(service_name, addresses)),
         ))
     }
@@ -90,12 +126,14 @@ impl Parser for IngressParser {
     async fn rule<'a>(
         &self,
         config: &serde_json::Value,
-        _context: ParseRuleContext<'a>,
+        context: ParseRuleContext<'a>,
     ) -> Result<Rule, Box<dyn Error>> {
         let p: Ingress = serde_json::from_value(config.to_owned())
             .map_err(|e| Box::new(RuleParseError::InvalidConfig(e)))?;
 
         let name = Meta::name(&p);
+        let annotations = p.metadata.annotations;
+
         let spec = p
             .spec
             .ok_or_else(|| Box::new(RuleParseError::MissingSpec))?;
@@ -120,13 +158,23 @@ impl Parser for IngressParser {
             .paths
             .get(0)
             .ok_or_else(|| Box::new(RuleParseError::MissingPath))?;
-        Self::parse_path(raw_path, host.clone(), name, self.priority)
-            .map_err(|e| Box::new(RuleParseError::InvalidPath(e)) as Box<dyn Error>)
+
+        Self::parse_path(
+            raw_path,
+            host.clone(),
+            name,
+            self.priority,
+            annotations,
+            context.middlewares,
+        )
+        .map_err(|e| Box::new(RuleParseError::InvalidPath(e)) as Box<dyn Error>)
     }
 }
 
 #[cfg(test)]
 mod tests {
+
+    use general_traits::DefaultConfig;
     use k8s_openapi::{
         api::extensions::v1beta1::{
             HTTPIngressRuleValue, IngressBackend, IngressRule, IngressSpec,
@@ -134,6 +182,7 @@ mod tests {
         apimachinery::pkg::util::intstr::IntOrString,
     };
     use kube::api::ObjectMeta;
+    use rules::{Action, Middleware};
 
     use crate::configurator::{MiddlewareList, ServiceList};
 
@@ -184,6 +233,214 @@ mod tests {
                 Matcher::PathPrefix("/test/".to_owned()),
             ]),
             vec![],
+            Shared::new(Service::new(
+                "test-service".to_owned(),
+                vec!["test-service:8080".to_owned()],
+            )),
+        );
+
+        assert_eq!(true, result.is_ok());
+        assert_eq!(expected, result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn valid_rule_with_one_middleware() {
+        let parser = IngressParser::new(10);
+
+        let ingress_rule = Ingress {
+            metadata: ObjectMeta {
+                name: Some("test-rule".to_owned()),
+                annotations: Some({
+                    let mut tmp = BTreeMap::new();
+                    tmp.insert(
+                        "tunneload-middleware".to_owned(),
+                        "test-middleware-1".to_owned(),
+                    );
+
+                    tmp
+                }),
+                ..Default::default()
+            },
+            spec: Some(IngressSpec {
+                rules: Some(vec![IngressRule {
+                    host: Some("example.com".to_owned()),
+                    http: Some(HTTPIngressRuleValue {
+                        paths: vec![HTTPIngressPath {
+                            path: Some("/test/".to_owned()),
+                            backend: IngressBackend {
+                                service_name: Some("test-service".to_owned()),
+                                service_port: Some(IntOrString::Int(8080)),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        }],
+                    }),
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let config = serde_json::to_value(ingress_rule).unwrap();
+
+        let mut middlwares = MiddlewareList::new();
+        middlwares.set(Middleware::new("test-middleware-1", Action::Compress));
+        let context = ParseRuleContext {
+            middlewares: &middlwares,
+            services: &ServiceList::default(),
+            cert_queue: None,
+        };
+
+        let result = parser.rule(&config, context).await;
+        let expected = Rule::new(
+            "test-rule".to_owned(),
+            10,
+            Matcher::And(vec![
+                Matcher::Domain("example.com".to_owned()),
+                Matcher::PathPrefix("/test/".to_owned()),
+            ]),
+            vec![Shared::new(Middleware::new(
+                "test-middleware-1",
+                Action::Compress,
+            ))],
+            Shared::new(Service::new(
+                "test-service".to_owned(),
+                vec!["test-service:8080".to_owned()],
+            )),
+        );
+
+        assert_eq!(true, result.is_ok());
+        assert_eq!(expected, result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn valid_rule_with_two_middleware() {
+        let parser = IngressParser::new(10);
+
+        let ingress_rule = Ingress {
+            metadata: ObjectMeta {
+                name: Some("test-rule".to_owned()),
+                annotations: Some({
+                    let mut tmp = BTreeMap::new();
+                    tmp.insert(
+                        "tunneload-middleware".to_owned(),
+                        "test-middleware-1, test-middleware-2".to_owned(),
+                    );
+
+                    tmp
+                }),
+                ..Default::default()
+            },
+            spec: Some(IngressSpec {
+                rules: Some(vec![IngressRule {
+                    host: Some("example.com".to_owned()),
+                    http: Some(HTTPIngressRuleValue {
+                        paths: vec![HTTPIngressPath {
+                            path: Some("/test/".to_owned()),
+                            backend: IngressBackend {
+                                service_name: Some("test-service".to_owned()),
+                                service_port: Some(IntOrString::Int(8080)),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        }],
+                    }),
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let config = serde_json::to_value(ingress_rule).unwrap();
+
+        let mut middlwares = MiddlewareList::new();
+        middlwares.set(Middleware::new("test-middleware-1", Action::Compress));
+        middlwares.set(Middleware::new("test-middleware-2", Action::Noop));
+        let context = ParseRuleContext {
+            middlewares: &middlwares,
+            services: &ServiceList::default(),
+            cert_queue: None,
+        };
+
+        let result = parser.rule(&config, context).await;
+        let expected = Rule::new(
+            "test-rule".to_owned(),
+            10,
+            Matcher::And(vec![
+                Matcher::Domain("example.com".to_owned()),
+                Matcher::PathPrefix("/test/".to_owned()),
+            ]),
+            vec![
+                Shared::new(Middleware::new("test-middleware-1", Action::Compress)),
+                Shared::new(Middleware::new("test-middleware-2", Action::Noop)),
+            ],
+            Shared::new(Service::new(
+                "test-service".to_owned(),
+                vec!["test-service:8080".to_owned()],
+            )),
+        );
+
+        assert_eq!(true, result.is_ok());
+        assert_eq!(expected, result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn valid_rule_with_unknown_middleware() {
+        let parser = IngressParser::new(10);
+
+        let ingress_rule = Ingress {
+            metadata: ObjectMeta {
+                name: Some("test-rule".to_owned()),
+                annotations: Some({
+                    let mut tmp = BTreeMap::new();
+                    tmp.insert(
+                        "tunneload-middleware".to_owned(),
+                        "test-middleware-1".to_owned(),
+                    );
+
+                    tmp
+                }),
+                ..Default::default()
+            },
+            spec: Some(IngressSpec {
+                rules: Some(vec![IngressRule {
+                    host: Some("example.com".to_owned()),
+                    http: Some(HTTPIngressRuleValue {
+                        paths: vec![HTTPIngressPath {
+                            path: Some("/test/".to_owned()),
+                            backend: IngressBackend {
+                                service_name: Some("test-service".to_owned()),
+                                service_port: Some(IntOrString::Int(8080)),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        }],
+                    }),
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let config = serde_json::to_value(ingress_rule).unwrap();
+
+        let context = ParseRuleContext {
+            middlewares: &MiddlewareList::new(),
+            services: &ServiceList::default(),
+            cert_queue: None,
+        };
+
+        let result = parser.rule(&config, context).await;
+        let expected = Rule::new(
+            "test-rule".to_owned(),
+            10,
+            Matcher::And(vec![
+                Matcher::Domain("example.com".to_owned()),
+                Matcher::PathPrefix("/test/".to_owned()),
+            ]),
+            vec![Shared::new(Middleware::default_name(
+                "test-middleware-1".to_string(),
+            ))],
             Shared::new(Service::new(
                 "test-service".to_owned(),
                 vec!["test-service:8080".to_owned()],


### PR DESCRIPTION
The Kubernetes Ingress Configurator can now also assign Middlewares to ingress Routes based on the
annotations set on the Ingress-Rule. For this it will look for a annotation with the key
'tunneload-middleware' and the Value should be a comma seperated List of the Middleware names.
These will then be applied to the final Rule as with any other Configurator